### PR TITLE
Result minor refactor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
 ﻿[*.{cs,vb}]
 
 # IDE0130: Namespace neodpovídá struktuře složek.
-dotnet_diagnostic.IDE0130.severity = information
+#dotnet_diagnostic.IDE0130.severity = information

--- a/Monads/Result.cs
+++ b/Monads/Result.cs
@@ -29,15 +29,15 @@ namespace Monads
         public bool IsOk => _error is null;
 
         /// <summary>
-        /// Returns true if the result is Err
+        /// Returns true if the result is Error
         /// </summary>
         /// <returns>
-        /// <see langword="true"/> if the result is Err.
+        /// <see langword="true"/> if the result is Error.
         /// <see langword="false"/> otherwise.
         /// </returns>
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(_error))]
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, nameof(_value))]
-        public bool IsErr => _error is not null;
+        public bool IsError => _error is not null;
 
         /// <summary>
         /// Unwraps the result, throwing an exception if the result is an error
@@ -52,7 +52,7 @@ namespace Monads
         /// <param name="msg">The message to include in the exception</param>
         /// <exception cref="Exception">The exception with the given message</exception>
         public void Expect(string msg) {
-            if (IsErr) throw new Exception(msg);
+            if (IsError) throw new Exception(msg);
         }
 
         /// <summary>
@@ -66,14 +66,14 @@ namespace Monads
         public bool IsOkAnd(Func<T, bool> f) => IsOk && f(_value);
 
         /// <summary>
-        /// Returns true if the result is Err and the error satisfies the predicate
+        /// Returns true if the result is Error and the error satisfies the predicate
         /// </summary>
         /// <param name="f">The predicate to test the error against</param>
         /// <returns>
-        /// <see langword="true"/> if the result is Err and the error satisfies the predicate.
+        /// <see langword="true"/> if the result is Error and the error satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsErrAnd(Func<E, bool> f) => IsErr && f(_error);
+        public bool IsErrorAnd(Func<E, bool> f) => IsError && f(_error);
 
         /// <summary>
         /// Returns an Option containing the value. Ok if the result is Ok, otherwise None.
@@ -82,19 +82,19 @@ namespace Monads
         public Option<T> Ok => IsOk ? new Some<T>(_value) : new None<T>();
 
         /// <summary>
-        /// Returns an Option containing the error. Some if the result is Err, otherwise None.
+        /// Returns an Option containing the error. Some if the result is Error, otherwise None.
         /// </summary>
-        /// <returns>An Option containing the error if the result is Err, otherwise None</returns>
-        public Option<E> Err => IsErr ? new Some<E>(_error) : new None<E>();
+        /// <returns>An Option containing the error if the result is Error, otherwise None</returns>
+        public Option<E> Error => IsError ? new Some<E>(_error) : new None<E>();
 
         /// <summary>
-        /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new Err
+        /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new Error
         /// </summary>
         /// <param name="op">The function to map the value to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
-        /// <returns>A new Result containing the mapped value if the result is Ok, otherwise a new Err containing the mapped error</returns>
+        /// <returns>A new Result containing the mapped value if the result is Ok, otherwise a new Error containing the mapped error</returns>
         public Result<U, E> Map<U>(Func<T, U> op) where U : class
-            => IsOk ? new Ok<U, E>(op(_value)) : new Err<U, E>(_error);
+            => IsOk ? new Ok<U, E>(op(_value)) : new Error<U, E>(_error);
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise returns a default value
@@ -116,13 +116,13 @@ namespace Monads
             => IsOk ? op(_value) : cb(_error);
 
         /// <summary>
-        /// Maps the error of the result to a new error if the result is Err, otherwise maps the value to a new Ok
+        /// Maps the error of the result to a new error if the result is Error, otherwise maps the value to a new Ok
         /// </summary>
         /// <param name="op">The function to map the error to a new error</param>
         /// <typeparam name="F">The type of the new error</typeparam>
-        /// <returns>A new Err containing the mapped error if the result is Err, otherwise a new Ok containing the mapped value</returns>
-        public Result<T, F> MapErr<F>(Func<E, F> op) where F : Exception
-            => IsOk ? new Ok<T, F>(_value) : new Err<T, F>(op(_error));
+        /// <returns>A new Error containing the mapped error if the result is Error, otherwise a new Ok containing the mapped value</returns>
+        public Result<T, F> MapError<F>(Func<E, F> op) where F : Exception
+            => IsOk ? new Ok<T, F>(_value) : new Error<T, F>(op(_error));
 
         /// <summary>
         /// Executes an action on the value if the result is Ok
@@ -135,11 +135,11 @@ namespace Monads
         }
 
         /// <summary>
-        /// Executes an action on the error if the result is Err
+        /// Executes an action on the error if the result is Error
         /// </summary>
         /// <param name="op">The action to execute on the error</param>
         /// <returns>Self</returns>
-        public Result<T, E> InspectErr(Action<E> op) {
+        public Result<T, E> InspectError(Action<E> op) {
             if (!IsOk) op(_error);
             return this;
         }
@@ -161,17 +161,17 @@ namespace Monads
     /// <param name="e">Error to return</param>
     /// <typeparam name="T">The type of the value</typeparam>
     /// <typeparam name="E">The type of the exception</typeparam>
-    public class Err<T, E>(E e) : Result<T, E>(e)
+    public class Error<T, E>(E e) : Result<T, E>(e)
         where E : Exception
         where T : class;
 
     public static class ResultExtensions
     {
         /// <summary>
-        /// Executes a function and wraps the result in Ok if the function executes successfully, otherwise wraps the exception in Err
+        /// Executes a function and wraps the result in Ok if the function executes successfully, otherwise wraps the exception in Error
         /// </summary>
         /// <param name="f">The function to execute</param>
-        /// <returns>A new Result containing the result of the function if it executes successfully, otherwise a new Err containing the exception</returns>
+        /// <returns>A new Result containing the result of the function if it executes successfully, otherwise a new Error containing the exception</returns>
         /// <typeparam name="T">The type of the value</typeparam>
         /// <typeparam name="E">The type of the exception</typeparam>
         /// <exception cref="Exception">An unexpected type of exception was thrown.</exception>
@@ -185,7 +185,7 @@ namespace Monads
             }
             catch (E e)
             {
-                return new Err<T, E>(e);
+                return new Error<T, E>(e);
             }
             catch (Exception e)
             {

--- a/Monads/Result.cs
+++ b/Monads/Result.cs
@@ -52,8 +52,7 @@ namespace Monads
         /// <param name="msg">The message to include in the exception</param>
         /// <exception cref="Exception">The exception with the given message</exception>
         public void Expect(string msg) {
-            if (IsErr)
-                throw new Exception(msg);
+            if (IsErr) throw new Exception(msg);
         }
 
         /// <summary>
@@ -64,7 +63,7 @@ namespace Monads
         /// <see langword="true"/> if the result is Ok and the value satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsOkAnd(Func<T,bool> f) => IsOk && f(_value);
+        public bool IsOkAnd(Func<T, bool> f) => IsOk && f(_value);
 
         /// <summary>
         /// Returns true if the result is Err and the error satisfies the predicate
@@ -74,7 +73,7 @@ namespace Monads
         /// <see langword="true"/> if the result is Err and the error satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsErrAnd(Func<E,bool> f) => IsErr && f(_error);
+        public bool IsErrAnd(Func<E, bool> f) => IsErr && f(_error);
 
         /// <summary>
         /// Returns an Option containing the value. Ok if the result is Ok, otherwise None.
@@ -94,7 +93,8 @@ namespace Monads
         /// <param name="op">The function to map the value to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>A new Result containing the mapped value if the result is Ok, otherwise a new Err containing the mapped error</returns>
-        public Result<U,E> Map<U>(Func<T,U> op) where U:class => IsOk ? new Ok<U,E>(op(_value)) : new Err<U,E>(_error);
+        public Result<U, E> Map<U>(Func<T, U> op) where U : class
+            => IsOk ? new Ok<U, E>(op(_value)) : new Err<U, E>(_error);
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise returns a default value
@@ -103,7 +103,7 @@ namespace Monads
         /// <param name="def">The default value to return if the result is an error</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>The mapped value if the result is Ok, otherwise the default value</returns>
-        public U MapOr<U>(Func<T,U> op, U def) => IsOk ? op(_value) : def;
+        public U MapOr<U>(Func<T, U> op, U def) => IsOk ? op(_value) : def;
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new value
@@ -112,7 +112,8 @@ namespace Monads
         /// <param name="cb">The function to map the error to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>The mapped value if the result is Ok, otherwise the mapped error</returns>
-        public U MapOrElse<U>(Func<T,U> op, Func<E,U> cb) => IsOk ? op(_value) : cb(_error);
+        public U MapOrElse<U>(Func<T, U> op, Func<E, U> cb)
+            => IsOk ? op(_value) : cb(_error);
 
         /// <summary>
         /// Maps the error of the result to a new error if the result is Err, otherwise maps the value to a new Ok
@@ -120,16 +121,16 @@ namespace Monads
         /// <param name="op">The function to map the error to a new error</param>
         /// <typeparam name="F">The type of the new error</typeparam>
         /// <returns>A new Err containing the mapped error if the result is Err, otherwise a new Ok containing the mapped value</returns>
-        public Result<T,F> MapErr<F>(Func<E,F> op) where F:Exception => IsOk ? new Ok<T,F>(_value) : new Err<T,F>(op(_error));
+        public Result<T, F> MapErr<F>(Func<E, F> op) where F : Exception
+            => IsOk ? new Ok<T, F>(_value) : new Err<T, F>(op(_error));
 
         /// <summary>
         /// Executes an action on the value if the result is Ok
         /// </summary>
         /// <param name="op">The action to execute on the value</param>
         /// <returns>Self</returns>
-        public Result<T,E> Inspect(Action<T> op) {
-            if (IsOk)
-                op(_value);
+        public Result<T, E> Inspect(Action<T> op) {
+            if (IsOk) op(_value);
             return this;
         }
 
@@ -138,9 +139,8 @@ namespace Monads
         /// </summary>
         /// <param name="op">The action to execute on the error</param>
         /// <returns>Self</returns>
-        public Result<T,E> InspectErr(Action<E> op) {
-            if (!IsOk)
-                op(_error);
+        public Result<T, E> InspectErr(Action<E> op) {
+            if (!IsOk) op(_error);
             return this;
         }
 
@@ -151,11 +151,15 @@ namespace Monads
         /// <returns>A new Result containing the result of the function if it executes successfully, otherwise a new Err containing the exception</returns>
         /// <typeparam name="T">The type of the value</typeparam>
         /// <typeparam name="E">The type of the exception</typeparam>
-        public static Result<T,E> Exec(Func<T> f) {
-            try {
-                return new Ok<T,E>(f());
-            } catch (E e) {
-                return new Err<T,E>(e);
+        /// <exception cref="Exception">An unexpected type of exception was thrown.</exception>
+        public static Result<T, E> Exec(Func<T> f) {
+            try
+            {
+                return new Ok<T, E>(f());
+            }
+            catch (E e)
+            {
+                return new Err<T, E>(e);
             }
         }
     }

--- a/Monads/Result.cs
+++ b/Monads/Result.cs
@@ -49,31 +49,32 @@ namespace Monads
         /// <summary>
         /// Unwraps the result, throwing an exception with the given message if the result is an error
         /// </summary>
-        /// <param name="msg">The message to include in the exception</param>
+        /// <param name="message">The message to include in the exception</param>
         /// <exception cref="Exception">The exception with the given message</exception>
-        public void Expect(string msg) {
-            if (IsError) throw new Exception(msg);
+        public void Expect(string message)
+        {
+            if (IsError) throw new Exception(message);
         }
 
         /// <summary>
         /// Returns <see langword="true"/> if the result is Ok and the value satisfies the predicate
         /// </summary>
-        /// <param name="f">The predicate to test the value against</param>
+        /// <param name="predicate">The predicate to test the value against</param>
         /// <returns>
         /// <see langword="true"/> if the result is Ok and the value satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsOkAnd(Func<T, bool> f) => IsOk && f(_value);
+        public bool IsOkAnd(Func<T, bool> predicate) => IsOk && predicate(_value);
 
         /// <summary>
         /// Returns true if the result is Error and the error satisfies the predicate
         /// </summary>
-        /// <param name="f">The predicate to test the error against</param>
+        /// <param name="predicate">The predicate to test the error against</param>
         /// <returns>
         /// <see langword="true"/> if the result is Error and the error satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsErrorAnd(Func<E, bool> f) => IsError && f(_error);
+        public bool IsErrorAnd(Func<E, bool> predicate) => IsError && predicate(_error);
 
         /// <summary>
         /// Returns an Option containing the value. Ok if the result is Ok, otherwise None.
@@ -90,57 +91,59 @@ namespace Monads
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new Error
         /// </summary>
-        /// <param name="op">The function to map the value to a new value</param>
+        /// <param name="operation">The function to map the value to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>A new Result containing the mapped value if the result is Ok, otherwise a new Error containing the mapped error</returns>
-        public Result<U, E> Map<U>(Func<T, U> op) where U : class
-            => IsOk ? new Ok<U, E>(op(_value)) : new Error<U, E>(_error);
+        public Result<U, E> Map<U>(Func<T, U> operation) where U : class
+            => IsOk ? new Ok<U, E>(operation(_value)) : new Error<U, E>(_error);
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise returns a default value
         /// </summary>
-        /// <param name="op">The function to map the value to a new value</param>
-        /// <param name="def">The default value to return if the result is an error</param>
+        /// <param name="operation">The function to map the value to a new value</param>
+        /// <param name="default">The default value to return if the result is an error</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>The mapped value if the result is Ok, otherwise the default value</returns>
-        public U MapOr<U>(Func<T, U> op, U def) => IsOk ? op(_value) : def;
+        public U MapOr<U>(Func<T, U> operation, U @default) => IsOk ? operation(_value) : @default;
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new value
         /// </summary>
-        /// <param name="op">The function to map the value to a new value</param>
-        /// <param name="cb">The function to map the error to a new value</param>
+        /// <param name="operation">The function to map the value to a new value</param>
+        /// <param name="else_cb">The function to map the error to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>The mapped value if the result is Ok, otherwise the mapped error</returns>
-        public U MapOrElse<U>(Func<T, U> op, Func<E, U> cb)
-            => IsOk ? op(_value) : cb(_error);
+        public U MapOrElse<U>(Func<T, U> operation, Func<E, U> else_cb)
+            => IsOk ? operation(_value) : else_cb(_error);
 
         /// <summary>
         /// Maps the error of the result to a new error if the result is Error, otherwise maps the value to a new Ok
         /// </summary>
-        /// <param name="op">The function to map the error to a new error</param>
+        /// <param name="operation">The function to map the error to a new error</param>
         /// <typeparam name="F">The type of the new error</typeparam>
         /// <returns>A new Error containing the mapped error if the result is Error, otherwise a new Ok containing the mapped value</returns>
-        public Result<T, F> MapError<F>(Func<E, F> op) where F : Exception
-            => IsOk ? new Ok<T, F>(_value) : new Error<T, F>(op(_error));
+        public Result<T, F> MapError<F>(Func<E, F> operation) where F : Exception
+            => IsOk ? new Ok<T, F>(_value) : new Error<T, F>(operation(_error));
 
         /// <summary>
         /// Executes an action on the value if the result is Ok
         /// </summary>
-        /// <param name="op">The action to execute on the value</param>
+        /// <param name="operation">The action to execute on the value</param>
         /// <returns>Self</returns>
-        public Result<T, E> Inspect(Action<T> op) {
-            if (IsOk) op(_value);
+        public Result<T, E> Inspect(Action<T> operation)
+        {
+            if (IsOk) operation(_value);
             return this;
         }
 
         /// <summary>
         /// Executes an action on the error if the result is Error
         /// </summary>
-        /// <param name="op">The action to execute on the error</param>
+        /// <param name="operation">The action to execute on the error</param>
         /// <returns>Self</returns>
-        public Result<T, E> InspectError(Action<E> op) {
-            if (!IsOk) op(_error);
+        public Result<T, E> InspectError(Action<E> operation)
+        {
+            if (!IsOk) operation(_error);
             return this;
         }
     }

--- a/Monads/Result.cs
+++ b/Monads/Result.cs
@@ -143,25 +143,6 @@ namespace Monads
             if (!IsOk) op(_error);
             return this;
         }
-
-        /// <summary>
-        /// Executes a function and wraps the result in Ok if the function executes successfully, otherwise wraps the exception in Err
-        /// </summary>
-        /// <param name="f">The function to execute</param>
-        /// <returns>A new Result containing the result of the function if it executes successfully, otherwise a new Err containing the exception</returns>
-        /// <typeparam name="T">The type of the value</typeparam>
-        /// <typeparam name="E">The type of the exception</typeparam>
-        /// <exception cref="Exception">An unexpected type of exception was thrown.</exception>
-        public static Result<T, E> Exec(Func<T> f) {
-            try
-            {
-                return new Ok<T, E>(f());
-            }
-            catch (E e)
-            {
-                return new Err<T, E>(e);
-            }
-        }
     }
 
     /// <summary>
@@ -183,4 +164,33 @@ namespace Monads
     public class Err<T, E>(E e) : Result<T, E>(e)
         where E : Exception
         where T : class;
+
+    public static class ResultExtensions
+    {
+        /// <summary>
+        /// Executes a function and wraps the result in Ok if the function executes successfully, otherwise wraps the exception in Err
+        /// </summary>
+        /// <param name="f">The function to execute</param>
+        /// <returns>A new Result containing the result of the function if it executes successfully, otherwise a new Err containing the exception</returns>
+        /// <typeparam name="T">The type of the value</typeparam>
+        /// <typeparam name="E">The type of the exception</typeparam>
+        /// <exception cref="Exception">An unexpected type of exception was thrown.</exception>
+        public static Result<T, E> TryExecute<T, E>(this Func<T> f)
+            where E : Exception
+            where T : class
+        {
+            try
+            {
+                return new Ok<T, E>(f());
+            }
+            catch (E e)
+            {
+                return new Err<T, E>(e);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Unexpected exception encountered", e);
+            }
+        }
+    }
 }

--- a/Monads/Result.cs
+++ b/Monads/Result.cs
@@ -8,11 +8,11 @@ namespace Monads
     /// <typeparam name="T">The type of the value</typeparam>
     /// <typeparam name="E">The type of the exception</typeparam>
     public class Result<T,E> where E:Exception where T:class {
-        T? value;
-        E? error;
+        protected T? _value;
+        protected E? _error;
 
-        private protected Result(T v) => value = v;
-        private protected Result(E e) => error = e;
+        private protected Result(T v) => _value = v;
+        private protected Result(E e) => _error = e;
 
         /// <summary>
         /// Returns true if the result is Ok
@@ -21,7 +21,7 @@ namespace Monads
         /// <see langword="true"/> if the result is Ok.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsOk => error is null;
+        public bool IsOk => _error is null;
 
         /// <summary>
         /// Returns true if the result is Err
@@ -37,7 +37,7 @@ namespace Monads
         /// </summary>
         /// <exception cref="E">The error that was wrapped in the result</exception>
         /// <returns>The value that was wrapped in the result</returns>
-        public T Unwrap => error is not null ? throw error : value!;
+        public T Unwrap => _error is not null ? throw _error : _value!;
 
         /// <summary>
         /// Unwraps the result, throwing an exception with the given message if the result is an error
@@ -45,7 +45,7 @@ namespace Monads
         /// <param name="msg">The message to include in the exception</param>
         /// <exception cref="Exception">The exception with the given message</exception>
         public void Expect(string msg) {
-            if (error is not null) {
+            if (_error is not null) {
                 throw new Exception(msg);
             }
         }
@@ -58,7 +58,7 @@ namespace Monads
         /// <see langword="true"/> if the result is Ok and the value satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsOkAnd(Func<T,bool> f) => IsOk && value is not null ? f(value) : false;
+        public bool IsOkAnd(Func<T,bool> f) => IsOk && _value is not null ? f(_value) : false;
 
         /// <summary>
         /// Returns true if the result is Err and the error satisfies the predicate
@@ -68,19 +68,19 @@ namespace Monads
         /// <see langword="true"/> if the result is Err and the error satisfies the predicate.
         /// <see langword="false"/> otherwise.
         /// </returns>
-        public bool IsErrAnd(Func<E,bool> f) => IsErr && error is not null ? f(error) : false;
+        public bool IsErrAnd(Func<E,bool> f) => IsErr && _error is not null ? f(_error) : false;
 
         /// <summary>
         /// Returns an Option containing the value. Ok if the result is Ok, otherwise None.
         /// </summary>
         /// <returns>An Option containing the value if the result is Ok, otherwise None</returns>
-        public Option<T> Ok => value is not null ? new Some<T>(value) : new None<T>();
+        public Option<T> Ok => _value is not null ? new Some<T>(_value) : new None<T>();
 
         /// <summary>
         /// Returns an Option containing the error. Some if the result is Err, otherwise None.
         /// </summary>
         /// <returns>An Option containing the error if the result is Err, otherwise None</returns>
-        public Option<E> Err => error is not null ? new Some<E>(error) : new None<E>();
+        public Option<E> Err => _error is not null ? new Some<E>(_error) : new None<E>();
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new Err
@@ -88,7 +88,7 @@ namespace Monads
         /// <param name="op">The function to map the value to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>A new Result containing the mapped value if the result is Ok, otherwise a new Err containing the mapped error</returns>
-        public Result<U,E> Map<U>(Func<T,U> op) where U:class => IsOk ? new Ok<U,E>(op(value!)) : new Err<U,E>(error!);
+        public Result<U,E> Map<U>(Func<T,U> op) where U:class => IsOk ? new Ok<U,E>(op(_value!)) : new Err<U,E>(_error!);
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise returns a default value
@@ -97,7 +97,7 @@ namespace Monads
         /// <param name="def">The default value to return if the result is an error</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>The mapped value if the result is Ok, otherwise the default value</returns>
-        public U MapOr<U>(Func<T,U> op, U def) => IsOk ? op(value!) : def;
+        public U MapOr<U>(Func<T,U> op, U def) => IsOk ? op(_value!) : def;
 
         /// <summary>
         /// Maps the value of the result to a new value if the result is Ok, otherwise maps the error to a new value
@@ -106,7 +106,7 @@ namespace Monads
         /// <param name="cb">The function to map the error to a new value</param>
         /// <typeparam name="U">The type of the new value</typeparam>
         /// <returns>The mapped value if the result is Ok, otherwise the mapped error</returns>
-        public U MapOrElse<U>(Func<T,U> op, Func<E,U> cb) => IsOk ? op(value!) : cb(error!);
+        public U MapOrElse<U>(Func<T,U> op, Func<E,U> cb) => IsOk ? op(_value!) : cb(_error!);
 
         /// <summary>
         /// Maps the error of the result to a new error if the result is Err, otherwise maps the value to a new Ok
@@ -114,7 +114,7 @@ namespace Monads
         /// <param name="op">The function to map the error to a new error</param>
         /// <typeparam name="F">The type of the new error</typeparam>
         /// <returns>A new Err containing the mapped error if the result is Err, otherwise a new Ok containing the mapped value</returns>
-        public Result<T,F> MapErr<F>(Func<E,F> op) where F:Exception => IsOk ? new Ok<T,F>(value!) : new Err<T,F>(op(error!));
+        public Result<T,F> MapErr<F>(Func<E,F> op) where F:Exception => IsOk ? new Ok<T,F>(_value!) : new Err<T,F>(op(_error!));
 
         /// <summary>
         /// Executes an action on the value if the result is Ok
@@ -123,7 +123,7 @@ namespace Monads
         /// <returns>Self</returns>
         public Result<T,E> Inspect(Action<T> op) {
             if (IsOk) {
-                op(value!);
+                op(_value!);
             }
             return this;
         }
@@ -135,7 +135,7 @@ namespace Monads
         /// <returns>Self</returns>
         public Result<T,E> InspectErr(Action<E> op) {
             if (!IsOk) {
-                op(error!);
+                op(_error!);
             }
             return this;
         }

--- a/Monads/Result.cs
+++ b/Monads/Result.cs
@@ -7,12 +7,15 @@ namespace Monads
     /// </summary>
     /// <typeparam name="T">The type of the value</typeparam>
     /// <typeparam name="E">The type of the exception</typeparam>
-    public class Result<T,E> where E:Exception where T:class {
+    public class Result<T, E>
+        where E : Exception
+        where T : class
+    {
         protected T? _value;
         protected E? _error;
 
-        private protected Result(T v) => _value = v;
-        private protected Result(E e) => _error = e;
+        protected Result(T v) => _value = v;
+        protected Result(E e) => _error = e;
 
         /// <summary>
         /// Returns true if the result is Ok
@@ -159,18 +162,20 @@ namespace Monads
     /// <summary>
     /// Represents a successful result
     /// </summary>
+    /// <param name="v">Value to return</param>
     /// <typeparam name="T">The type of the value</typeparam>
     /// <typeparam name="E">The type of the exception</typeparam>
-    public class Ok<T,E> : Result<T,E> where E:Exception where T:class {
-        public Ok(T v) : base(v) {}
-    }
+    public class Ok<T, E>(T v) : Result<T, E>(v)
+        where E : Exception
+        where T : class;
 
     /// <summary>
     /// Represents a failed result
     /// </summary>
+    /// <param name="e">Error to return</param>
     /// <typeparam name="T">The type of the value</typeparam>
     /// <typeparam name="E">The type of the exception</typeparam>
-    public class Err<T,E> : Result<T,E> where E:Exception where T:class {
-        public Err(E e) : base(e) {}
-    }
+    public class Err<T, E>(E e) : Result<T, E>(e)
+        where E : Exception
+        where T : class;
 }

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -15,9 +15,9 @@ namespace Monads.Tests
         }
 
         [TestMethod]
-        public void IsErrTest() {
-            var result = new Err<Object,Exception>(testError);
-            IsTrue(result.IsErr);
+        public void IsErrorTest() {
+            var result = new Error<Object,Exception>(testError);
+            IsTrue(result.IsError);
         }
 
         [TestMethod]
@@ -27,8 +27,8 @@ namespace Monads.Tests
         }
 
         [TestMethod]
-        public void UnwrapErrTest() {
-            var result = new Err<Object,Exception>(testError);
+        public void UnwrapErrorTest() {
+            var result = new Error<Object,Exception>(testError);
             try {
                 _ = result.Unwrap;
                 Fail("Expected exception was not thrown");
@@ -45,9 +45,9 @@ namespace Monads.Tests
         }
 
         [TestMethod]
-        public void ExpectErrTest() {
+        public void ExpectErrorTest() {
             var msg = "Error";
-            var result = new Err<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(testError);
             try {
                 result.Expect(msg);
                 Fail("Expected exception was not thrown");
@@ -71,24 +71,24 @@ namespace Monads.Tests
         }
 
         [TestMethod]
-        public void IsErrAndTest() {
-            var result = new Err<Object,Exception>(testError);
+        public void IsErrorAndTest() {
+            var result = new Error<Object,Exception>(testError);
             var predicate = (Exception e) => e.Message == testError.Message;
-            IsTrue(result.IsErrAnd(predicate));
+            IsTrue(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
-        public void IsErrAndFalseTest() {
-            var result = new Err<Object,Exception>(testError);
+        public void IsErrorAndFalseTest() {
+            var result = new Error<Object,Exception>(testError);
             var predicate = (Exception e) => e.Message == "Different Error";
-            IsFalse(result.IsErrAnd(predicate));
+            IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
-        public void IsErrAndNullTest() {
-            var result = new Err<Object,Exception>(testError);
+        public void IsErrorAndNullTest() {
+            var result = new Error<Object,Exception>(testError);
             var predicate = (Exception e) => e is null;
-            IsFalse(result.IsErrAnd(predicate));
+            IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
@@ -106,10 +106,10 @@ namespace Monads.Tests
         }
 
         [TestMethod]
-        public void IsErrAndNullPredicateTest() {
-            var result = new Err<Object,Exception>(testError);
+        public void IsErrorAndNullPredicateTest() {
+            var result = new Error<Object,Exception>(testError);
             var predicate = (Exception e) => e is null;
-            IsFalse(result.IsErrAnd(predicate));
+            IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
@@ -120,20 +120,20 @@ namespace Monads.Tests
 
         [TestMethod]
         public void OkTestNull() {
-            var result = new Err<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(testError);
             IsFalse(result.Ok.HasValue);
         }
 
         [TestMethod]
-        public void ErrTest() {
-            var result = new Err<Object,Exception>(testError);
-            IsTrue(result.Err.Value == testError);
+        public void ErrorTest() {
+            var result = new Error<Object,Exception>(testError);
+            IsTrue(result.Error.Value == testError);
         }
 
         [TestMethod]
-        public void ErrTestNull() {
+        public void ErrorTestNull() {
             var result = new Ok<Object,Exception>(testValue);
-            IsFalse(result.Err.HasValue);
+            IsFalse(result.Error.HasValue);
         }
 
         [TestMethod]
@@ -146,9 +146,9 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapErrorTest() {
-            var result = new Err<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(testError);
             var mappedResult = result.Map(v => v.ToString()!);
-            IsTrue(mappedResult.IsErr);
+            IsTrue(mappedResult.IsError);
             try {
                 _ = mappedResult.Unwrap;
                 Fail("Expected exception was not thrown");
@@ -166,7 +166,7 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapOrTestNull() {
-            var result = new Err<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(testError);
             var mappedResult = result.MapOr(v => v.ToString()!, testValue);
             AreSame(testValue, mappedResult);
         }
@@ -180,29 +180,30 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapOrElseTestNull() {
-            var result = new Err<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(testError);
             var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(testError.Message, mappedResult);
         }
 
         [TestMethod]
-        public void MapErrTest() {
-            var result = new Err<Object,Exception>(testError);
-            var mappedResult = result.MapErr(e => new Exception("Mapped Error"));
-            IsTrue(mappedResult.IsErr);
+        public void MapErrorDiffTest() {
+            var result = new Error<Object,Exception>(testError);
+            const string message = "Mapped Error";
+            var mappedResult = result.MapError(e => new Exception(message));
+            IsTrue(mappedResult.IsError);
             try {
                 _ = mappedResult.Unwrap;
                 Fail("Expected exception was not thrown");
             } catch (Exception ex) {
                 AreNotSame(testError, ex);
-                AreSame(ex.Message, "Mapped Error");
+                AreSame(ex.Message, message);
             }
         }
 
         [TestMethod]
-        public void MapErrTestNull() {
+        public void MapErrorTestNull() {
             var result = new Ok<Object,Exception>(testValue);
-            var mappedResult = result.MapErr(e => new Exception("Mapped Error"));
+            var mappedResult = result.MapError(e => new Exception("Mapped Error"));
             IsTrue(mappedResult.IsOk);
             AreSame(testValue, mappedResult.Unwrap);
         }
@@ -220,7 +221,7 @@ namespace Monads.Tests
         {
             var testFunc = static () => false ? string.Empty : throw new InvalidOperationException();
             var result = testFunc.TryExecute<string, InvalidOperationException>();
-            IsTrue(result.IsErr);
+            IsTrue(result.IsError);
         }
 
         [TestMethod]

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -5,30 +5,30 @@ namespace Monads.Tests
     [TestClass]
     public class ResultTests
     {
-        private static object _testValue = new object();
-        private static Exception _testError = new Exception("Test exception");
+        private static object _testValue = new();
+        private static Exception _testError = new("Test exception");
 
         [TestMethod]
         public void IsOkTest() {
-            var result = new Ok<object, Exception>(_testValue);
+            Ok<object, Exception> result = new(_testValue);
             IsTrue(result.IsOk);
         }
 
         [TestMethod]
         public void IsErrorTest() {
-            var result = new Error<object, Exception>(_testError);
+            Error<object, Exception> result = new(_testError);
             IsTrue(result.IsError);
         }
 
         [TestMethod]
         public void UnwrapTest() {
-            var result = new Ok<object, Exception>(_testValue);
+            Ok<object, Exception> result = new(_testValue);
             AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
         public void UnwrapErrorTest() {
-            var result = new Error<object, Exception>(_testError);
+            Error<object, Exception> result = new(_testError);
             try {
                 _ = result.Unwrap;
                 Fail("Expected exception was not thrown");
@@ -39,15 +39,15 @@ namespace Monads.Tests
 
         [TestMethod]
         public void ExpectTest() {
-            var result = new Ok<object, Exception>(_testValue);
+            Ok<object, Exception> result = new(_testValue);
             result.Expect("Error");
             AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
         public void ExpectErrorTest() {
-            var msg = "Error";
-            var result = new Error<object, Exception>(_testError);
+            string msg = "Error";
+            Error<object, Exception> result = new(_testError);
             try {
                 result.Expect(msg);
                 Fail("Expected exception was not thrown");
@@ -58,96 +58,96 @@ namespace Monads.Tests
 
         [TestMethod]
         public void IsOkAndTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var predicate = (object v) => v is not null;
+            Ok<object, Exception> result = new(_testValue);
+            Func<object, bool> predicate = (object v) => v is not null;
             IsTrue(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndFalseTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var predicate = (object v) => v is null;
+            Ok<object, Exception> result = new(_testValue);
+            Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndTest() {
-            var result = new Error<object, Exception>(_testError);
-            var predicate = (Exception e) => e.Message == _testError.Message;
+            Error<object, Exception> result = new(_testError);
+            Func<Exception, bool> predicate = (Exception e) => e.Message == _testError.Message;
             IsTrue(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndFalseTest() {
-            var result = new Error<object, Exception>(_testError);
-            var predicate = (Exception e) => e.Message == "Different Error";
+            Error<object, Exception> result = new(_testError);
+            Func<Exception, bool> predicate = (Exception e) => e.Message == "Different Error";
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndNullTest() {
-            var result = new Error<object, Exception>(_testError);
-            var predicate = (Exception e) => e is null;
+            Error<object, Exception> result = new(_testError);
+            Func<Exception, bool> predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndNullTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var predicate = (object v) => v is null;
+            Ok<object, Exception> result = new(_testValue);
+            Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndNullPredicateTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var predicate = (object v) => v is null;
+            Ok<object, Exception> result = new(_testValue);
+            Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndNullPredicateTest() {
-            var result = new Error<object, Exception>(_testError);
-            var predicate = (Exception e) => e is null;
+            Error<object, Exception> result = new(_testError);
+            Func<Exception, bool> predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void OkTest() {
-            var result = new Ok<object, Exception>(_testValue);
+            Ok<object, Exception> result = new(_testValue);
             IsTrue(result.Ok.Value == _testValue);
         }
 
         [TestMethod]
         public void OkNullTest() {
-            var result = new Error<object, Exception>(_testError);
+            Error<object, Exception> result = new(_testError);
             IsFalse(result.Ok.HasValue);
         }
 
         [TestMethod]
         public void ErrorTest() {
-            var result = new Error<object, Exception>(_testError);
+            Error<object, Exception> result = new(_testError);
             IsTrue(result.Error.Value == _testError);
         }
 
         [TestMethod]
         public void ErrorNullTest() {
-            var result = new Ok<object, Exception>(_testValue);
+            Ok<object, Exception> result = new(_testValue);
             IsFalse(result.Error.HasValue);
         }
 
         [TestMethod]
         public void MapTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var mappedResult = result.Map(v => v.ToString()!);
+            Ok<object, Exception> result = new(_testValue);
+            Result<string, Exception> mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsOk);
             AreNotSame(_testValue, mappedResult.Unwrap);
         }
 
         [TestMethod]
         public void MapErrorTest() {
-            var result = new Error<object, Exception>(_testError);
-            var mappedResult = result.Map(v => v.ToString()!);
+            Error<object, Exception> result = new(_testError);
+            Result<string, Exception> mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsError);
             try {
                 _ = mappedResult.Unwrap;
@@ -159,37 +159,37 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapOrTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var mappedResult = result.MapOr(v => v.ToString()!, new object());
+            Ok<object, Exception> result = new(_testValue);
+            object mappedResult = result.MapOr(v => v.ToString()!, new object());
             AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
         public void MapOrNullTest() {
-            var result = new Error<object, Exception>(_testError);
-            var mappedResult = result.MapOr(v => v.ToString()!, _testValue);
+            Error<object, Exception> result = new(_testError);
+            object mappedResult = result.MapOr(v => v.ToString()!, _testValue);
             AreSame(_testValue, mappedResult);
         }
 
         [TestMethod]
         public void MapOrElseTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
+            Ok<object, Exception> result = new(_testValue);
+            string mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
         public void MapOrElseNullTest() {
-            var result = new Error<object, Exception>(_testError);
-            var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
+            Error<object, Exception> result = new(_testError);
+            string mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testError.Message, mappedResult);
         }
 
         [TestMethod]
         public void MapErrorDiffTest() {
-            var result = new Error<object, Exception>(_testError);
+            Error<object, Exception> result = new(_testError);
             const string message = "Mapped Error";
-            var mappedResult = result.MapError(e => new Exception(message));
+            Result<object, Exception> mappedResult = result.MapError(e => new Exception(message));
             IsTrue(mappedResult.IsError);
             try {
                 _ = mappedResult.Unwrap;
@@ -202,8 +202,8 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapErrorNullTest() {
-            var result = new Ok<object, Exception>(_testValue);
-            var mappedResult = result.MapError(e => new Exception("Mapped Error"));
+            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> mappedResult = result.MapError(e => new Exception("Mapped Error"));
             IsTrue(mappedResult.IsOk);
             AreSame(_testValue, mappedResult.Unwrap);
         }
@@ -211,24 +211,24 @@ namespace Monads.Tests
         [TestMethod]
         public void TryExecuteSucceedTest()
         {
-            var testFunc = static () => "ahoj";
-            var result = testFunc.TryExecute<string, Exception>();
+            Func<string> testFunc = static () => "ahoj";
+            Result<string, Exception> result = testFunc.TryExecute<string, Exception>();
             IsTrue(result.IsOk);
         }
 
         [TestMethod]
         public void TryExecuteFailTest()
         {
-            var testFunc = static () => false ? string.Empty : throw new InvalidOperationException();
-            var result = testFunc.TryExecute<string, InvalidOperationException>();
+            Func<string> testFunc = static () => false ? string.Empty : throw new InvalidOperationException();
+            Result<string, InvalidOperationException> result = testFunc.TryExecute<string, InvalidOperationException>();
             IsTrue(result.IsError);
         }
 
         [TestMethod]
         public void TryExecuteUnexpectedTest()
         {
-            ArgumentException exception = new(); 
-            var testFunc = () => false ? string.Empty : throw exception;
+            ArgumentException exception = new();
+            Func<string> testFunc = () => false ? string.Empty : throw exception;
             Result<string, InvalidOperationException> result = default!;
             try
             {

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -206,5 +206,39 @@ namespace Monads.Tests
             IsTrue(mappedResult.IsOk);
             AreSame(testValue, mappedResult.Unwrap);
         }
+
+        [TestMethod]
+        public void TryExecuteSucceedTest()
+        {
+            var testFunc = static () => "ahoj";
+            var result = testFunc.TryExecute<string, Exception>();
+            IsTrue(result.IsOk);
+        }
+
+        [TestMethod]
+        public void TryExecuteFailTest()
+        {
+            var testFunc = static () => false ? string.Empty : throw new InvalidOperationException();
+            var result = testFunc.TryExecute<string, InvalidOperationException>();
+            IsTrue(result.IsErr);
+        }
+
+        [TestMethod]
+        public void TryExecuteUnexpectedTest()
+        {
+            ArgumentException exception = new(); 
+            var testFunc = () => false ? string.Empty : throw exception;
+            Result<string, InvalidOperationException> result = default!;
+            try
+            {
+                result = testFunc.TryExecute<string, InvalidOperationException>();
+                Fail("Didn't throw");
+            }
+            catch (Exception e)
+            {
+                AreEqual(exception, e.InnerException);
+            }
+            IsNull(result);
+        }
     }
 }

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -5,49 +5,49 @@ namespace Monads.Tests
     [TestClass]
     public class ResultTests
     {
-        private static Object testValue = new Object();
-        private static Exception testError = new Exception("Test exception");
+        private static Object _testValue = new Object();
+        private static Exception _testError = new Exception("Test exception");
 
         [TestMethod]
         public void IsOkTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             IsTrue(result.IsOk);
         }
 
         [TestMethod]
         public void IsErrorTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             IsTrue(result.IsError);
         }
 
         [TestMethod]
         public void UnwrapTest() {
-            var result = new Ok<Object,Exception>(testValue);
-            AreSame(testValue, result.Unwrap);
+            var result = new Ok<Object,Exception>(_testValue);
+            AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
         public void UnwrapErrorTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             try {
                 _ = result.Unwrap;
                 Fail("Expected exception was not thrown");
             } catch (Exception ex) {
-                AreSame(testError, ex);
+                AreSame(_testError, ex);
             }
         }
 
         [TestMethod]
         public void ExpectTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             result.Expect("Error");
-            AreSame(testValue, result.Unwrap);
+            AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
         public void ExpectErrorTest() {
             var msg = "Error";
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             try {
                 result.Expect(msg);
                 Fail("Expected exception was not thrown");
@@ -58,136 +58,136 @@ namespace Monads.Tests
 
         [TestMethod]
         public void IsOkAndTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var predicate = (object v) => v is not null;
             IsTrue(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndFalseTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndTest() {
-            var result = new Error<Object,Exception>(testError);
-            var predicate = (Exception e) => e.Message == testError.Message;
+            var result = new Error<Object,Exception>(_testError);
+            var predicate = (Exception e) => e.Message == _testError.Message;
             IsTrue(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndFalseTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             var predicate = (Exception e) => e.Message == "Different Error";
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndNullTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             var predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndNullTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndNullPredicateTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndNullPredicateTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             var predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void OkTest() {
-            var result = new Ok<Object,Exception>(testValue);
-            IsTrue(result.Ok.Value == testValue);
+            var result = new Ok<Object,Exception>(_testValue);
+            IsTrue(result.Ok.Value == _testValue);
         }
 
         [TestMethod]
-        public void OkTestNull() {
-            var result = new Error<Object,Exception>(testError);
+        public void OkNullTest() {
+            var result = new Error<Object,Exception>(_testError);
             IsFalse(result.Ok.HasValue);
         }
 
         [TestMethod]
         public void ErrorTest() {
-            var result = new Error<Object,Exception>(testError);
-            IsTrue(result.Error.Value == testError);
+            var result = new Error<Object,Exception>(_testError);
+            IsTrue(result.Error.Value == _testError);
         }
 
         [TestMethod]
-        public void ErrorTestNull() {
-            var result = new Ok<Object,Exception>(testValue);
+        public void ErrorNullTest() {
+            var result = new Ok<Object,Exception>(_testValue);
             IsFalse(result.Error.HasValue);
         }
 
         [TestMethod]
         public void MapTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsOk);
-            AreNotSame(testValue, mappedResult.Unwrap);
+            AreNotSame(_testValue, mappedResult.Unwrap);
         }
 
         [TestMethod]
         public void MapErrorTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             var mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsError);
             try {
                 _ = mappedResult.Unwrap;
                 Fail("Expected exception was not thrown");
             } catch (Exception ex) {
-                AreSame(testError, ex);
+                AreSame(_testError, ex);
             }
         }
 
         [TestMethod]
         public void MapOrTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var mappedResult = result.MapOr(v => v.ToString()!, new Object());
-            AreSame(testValue.ToString(), mappedResult);
+            AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
-        public void MapOrTestNull() {
-            var result = new Error<Object,Exception>(testError);
-            var mappedResult = result.MapOr(v => v.ToString()!, testValue);
-            AreSame(testValue, mappedResult);
+        public void MapOrNullTest() {
+            var result = new Error<Object,Exception>(_testError);
+            var mappedResult = result.MapOr(v => v.ToString()!, _testValue);
+            AreSame(_testValue, mappedResult);
         }
 
         [TestMethod]
         public void MapOrElseTest() {
-            var result = new Ok<Object,Exception>(testValue);
+            var result = new Ok<Object,Exception>(_testValue);
             var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
-            AreSame(testValue.ToString(), mappedResult);
+            AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
-        public void MapOrElseTestNull() {
-            var result = new Error<Object,Exception>(testError);
+        public void MapOrElseNullTest() {
+            var result = new Error<Object,Exception>(_testError);
             var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
-            AreSame(testError.Message, mappedResult);
+            AreSame(_testError.Message, mappedResult);
         }
 
         [TestMethod]
         public void MapErrorDiffTest() {
-            var result = new Error<Object,Exception>(testError);
+            var result = new Error<Object,Exception>(_testError);
             const string message = "Mapped Error";
             var mappedResult = result.MapError(e => new Exception(message));
             IsTrue(mappedResult.IsError);
@@ -195,17 +195,17 @@ namespace Monads.Tests
                 _ = mappedResult.Unwrap;
                 Fail("Expected exception was not thrown");
             } catch (Exception ex) {
-                AreNotSame(testError, ex);
+                AreNotSame(_testError, ex);
                 AreSame(ex.Message, message);
             }
         }
 
         [TestMethod]
-        public void MapErrorTestNull() {
-            var result = new Ok<Object,Exception>(testValue);
+        public void MapErrorNullTest() {
+            var result = new Ok<Object,Exception>(_testValue);
             var mappedResult = result.MapError(e => new Exception("Mapped Error"));
             IsTrue(mappedResult.IsOk);
-            AreSame(testValue, mappedResult.Unwrap);
+            AreSame(_testValue, mappedResult.Unwrap);
         }
 
         [TestMethod]

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -5,30 +5,30 @@ namespace Monads.Tests
     [TestClass]
     public class ResultTests
     {
-        private static Object _testValue = new Object();
+        private static object _testValue = new object();
         private static Exception _testError = new Exception("Test exception");
 
         [TestMethod]
         public void IsOkTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             IsTrue(result.IsOk);
         }
 
         [TestMethod]
         public void IsErrorTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             IsTrue(result.IsError);
         }
 
         [TestMethod]
         public void UnwrapTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
         public void UnwrapErrorTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             try {
                 _ = result.Unwrap;
                 Fail("Expected exception was not thrown");
@@ -39,7 +39,7 @@ namespace Monads.Tests
 
         [TestMethod]
         public void ExpectTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             result.Expect("Error");
             AreSame(_testValue, result.Unwrap);
         }
@@ -47,7 +47,7 @@ namespace Monads.Tests
         [TestMethod]
         public void ExpectErrorTest() {
             var msg = "Error";
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             try {
                 result.Expect(msg);
                 Fail("Expected exception was not thrown");
@@ -58,87 +58,87 @@ namespace Monads.Tests
 
         [TestMethod]
         public void IsOkAndTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var predicate = (object v) => v is not null;
             IsTrue(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndFalseTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var predicate = (Exception e) => e.Message == _testError.Message;
             IsTrue(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndFalseTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var predicate = (Exception e) => e.Message == "Different Error";
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndNullTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndNullTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsOkAndNullPredicateTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
         public void IsErrorAndNullPredicateTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
         public void OkTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             IsTrue(result.Ok.Value == _testValue);
         }
 
         [TestMethod]
         public void OkNullTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             IsFalse(result.Ok.HasValue);
         }
 
         [TestMethod]
         public void ErrorTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             IsTrue(result.Error.Value == _testError);
         }
 
         [TestMethod]
         public void ErrorNullTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             IsFalse(result.Error.HasValue);
         }
 
         [TestMethod]
         public void MapTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsOk);
             AreNotSame(_testValue, mappedResult.Unwrap);
@@ -146,7 +146,7 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapErrorTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsError);
             try {
@@ -159,35 +159,35 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapOrTest() {
-            var result = new Ok<Object,Exception>(_testValue);
-            var mappedResult = result.MapOr(v => v.ToString()!, new Object());
+            var result = new Ok<object, Exception>(_testValue);
+            var mappedResult = result.MapOr(v => v.ToString()!, new object());
             AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
         public void MapOrNullTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var mappedResult = result.MapOr(v => v.ToString()!, _testValue);
             AreSame(_testValue, mappedResult);
         }
 
         [TestMethod]
         public void MapOrElseTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
         public void MapOrElseNullTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             var mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testError.Message, mappedResult);
         }
 
         [TestMethod]
         public void MapErrorDiffTest() {
-            var result = new Error<Object,Exception>(_testError);
+            var result = new Error<object, Exception>(_testError);
             const string message = "Mapped Error";
             var mappedResult = result.MapError(e => new Exception(message));
             IsTrue(mappedResult.IsError);
@@ -202,7 +202,7 @@ namespace Monads.Tests
 
         [TestMethod]
         public void MapErrorNullTest() {
-            var result = new Ok<Object,Exception>(_testValue);
+            var result = new Ok<object, Exception>(_testValue);
             var mappedResult = result.MapError(e => new Exception("Mapped Error"));
             IsTrue(mappedResult.IsOk);
             AreSame(_testValue, mappedResult.Unwrap);

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -11,28 +11,28 @@ namespace Monads.Tests
         [TestMethod]
         public void IsOkTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             IsTrue(result.IsOk);
         }
 
         [TestMethod]
         public void IsErrorTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             IsTrue(result.IsError);
         }
 
         [TestMethod]
         public void UnwrapTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
         public void UnwrapErrorTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             try
             {
                 _ = result.Unwrap;
@@ -47,7 +47,7 @@ namespace Monads.Tests
         [TestMethod]
         public void ExpectTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             result.Expect("Error");
             AreSame(_testValue, result.Unwrap);
         }
@@ -56,7 +56,7 @@ namespace Monads.Tests
         public void ExpectErrorTest()
         {
             string msg = "Error";
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             try
             {
                 result.Expect(msg);
@@ -71,7 +71,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsOkAndTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             Func<object, bool> predicate = (object v) => v is not null;
             IsTrue(result.IsOkAnd(predicate));
         }
@@ -79,7 +79,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsOkAndFalseTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
@@ -87,7 +87,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsErrorAndTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             Func<Exception, bool> predicate = (Exception e) => e.Message == _testError.Message;
             IsTrue(result.IsErrorAnd(predicate));
         }
@@ -95,7 +95,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsErrorAndFalseTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             Func<Exception, bool> predicate = (Exception e) => e.Message == "Different Error";
             IsFalse(result.IsErrorAnd(predicate));
         }
@@ -103,7 +103,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsErrorAndNullTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             Func<Exception, bool> predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
@@ -111,7 +111,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsOkAndNullTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
@@ -119,7 +119,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsOkAndNullPredicateTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
@@ -127,7 +127,7 @@ namespace Monads.Tests
         [TestMethod]
         public void IsErrorAndNullPredicateTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             Func<Exception, bool> predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
@@ -135,35 +135,35 @@ namespace Monads.Tests
         [TestMethod]
         public void OkTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             IsTrue(result.Ok.Value == _testValue);
         }
 
         [TestMethod]
         public void OkNullTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             IsFalse(result.Ok.HasValue);
         }
 
         [TestMethod]
         public void ErrorTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             IsTrue(result.Error.Value == _testError);
         }
 
         [TestMethod]
         public void ErrorNullTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             IsFalse(result.Error.HasValue);
         }
 
         [TestMethod]
         public void MapTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             Result<string, Exception> mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsOk);
             AreNotSame(_testValue, mappedResult.Unwrap);
@@ -172,7 +172,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapErrorTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             Result<string, Exception> mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsError);
             try
@@ -189,7 +189,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapOrTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             object mappedResult = result.MapOr(v => v.ToString()!, new object());
             AreSame(_testValue.ToString(), mappedResult);
         }
@@ -197,7 +197,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapOrNullTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             object mappedResult = result.MapOr(v => v.ToString()!, _testValue);
             AreSame(_testValue, mappedResult);
         }
@@ -205,7 +205,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapOrElseTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             string mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testValue.ToString(), mappedResult);
         }
@@ -213,7 +213,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapOrElseNullTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             string mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testError.Message, mappedResult);
         }
@@ -221,7 +221,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapErrorDiffTest()
         {
-            Error<object, Exception> result = new(_testError);
+            Result<object, Exception> result = new Error<object, Exception>(_testError);
             const string message = "Mapped Error";
             Result<object, Exception> mappedResult = result.MapError(e => new Exception(message));
             IsTrue(mappedResult.IsError);
@@ -240,7 +240,7 @@ namespace Monads.Tests
         [TestMethod]
         public void MapErrorNullTest()
         {
-            Ok<object, Exception> result = new(_testValue);
+            Result<object, Exception> result = new Ok<object, Exception>(_testValue);
             Result<object, Exception> mappedResult = result.MapError(e => new Exception("Mapped Error"));
             IsTrue(mappedResult.IsOk);
             AreSame(_testValue, mappedResult.Unwrap);

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -9,135 +9,160 @@ namespace Monads.Tests
         private static Exception _testError = new("Test exception");
 
         [TestMethod]
-        public void IsOkTest() {
+        public void IsOkTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             IsTrue(result.IsOk);
         }
 
         [TestMethod]
-        public void IsErrorTest() {
+        public void IsErrorTest()
+        {
             Error<object, Exception> result = new(_testError);
             IsTrue(result.IsError);
         }
 
         [TestMethod]
-        public void UnwrapTest() {
+        public void UnwrapTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
-        public void UnwrapErrorTest() {
+        public void UnwrapErrorTest()
+        {
             Error<object, Exception> result = new(_testError);
-            try {
+            try
+            {
                 _ = result.Unwrap;
                 Fail("Expected exception was not thrown");
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 AreSame(_testError, ex);
             }
         }
 
         [TestMethod]
-        public void ExpectTest() {
+        public void ExpectTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             result.Expect("Error");
             AreSame(_testValue, result.Unwrap);
         }
 
         [TestMethod]
-        public void ExpectErrorTest() {
+        public void ExpectErrorTest()
+        {
             string msg = "Error";
             Error<object, Exception> result = new(_testError);
-            try {
+            try
+            {
                 result.Expect(msg);
                 Fail("Expected exception was not thrown");
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 AreSame(ex.Message, msg);
             }
         }
 
         [TestMethod]
-        public void IsOkAndTest() {
+        public void IsOkAndTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             Func<object, bool> predicate = (object v) => v is not null;
             IsTrue(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
-        public void IsOkAndFalseTest() {
+        public void IsOkAndFalseTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
-        public void IsErrorAndTest() {
+        public void IsErrorAndTest()
+        {
             Error<object, Exception> result = new(_testError);
             Func<Exception, bool> predicate = (Exception e) => e.Message == _testError.Message;
             IsTrue(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
-        public void IsErrorAndFalseTest() {
+        public void IsErrorAndFalseTest()
+        {
             Error<object, Exception> result = new(_testError);
             Func<Exception, bool> predicate = (Exception e) => e.Message == "Different Error";
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
-        public void IsErrorAndNullTest() {
+        public void IsErrorAndNullTest()
+        {
             Error<object, Exception> result = new(_testError);
             Func<Exception, bool> predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
-        public void IsOkAndNullTest() {
+        public void IsOkAndNullTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
-        public void IsOkAndNullPredicateTest() {
+        public void IsOkAndNullPredicateTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             Func<object, bool> predicate = (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
         [TestMethod]
-        public void IsErrorAndNullPredicateTest() {
+        public void IsErrorAndNullPredicateTest()
+        {
             Error<object, Exception> result = new(_testError);
             Func<Exception, bool> predicate = (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
         [TestMethod]
-        public void OkTest() {
+        public void OkTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             IsTrue(result.Ok.Value == _testValue);
         }
 
         [TestMethod]
-        public void OkNullTest() {
+        public void OkNullTest()
+        {
             Error<object, Exception> result = new(_testError);
             IsFalse(result.Ok.HasValue);
         }
 
         [TestMethod]
-        public void ErrorTest() {
+        public void ErrorTest()
+        {
             Error<object, Exception> result = new(_testError);
             IsTrue(result.Error.Value == _testError);
         }
 
         [TestMethod]
-        public void ErrorNullTest() {
+        public void ErrorNullTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             IsFalse(result.Error.HasValue);
         }
 
         [TestMethod]
-        public void MapTest() {
+        public void MapTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             Result<string, Exception> mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsOk);
@@ -145,63 +170,76 @@ namespace Monads.Tests
         }
 
         [TestMethod]
-        public void MapErrorTest() {
+        public void MapErrorTest()
+        {
             Error<object, Exception> result = new(_testError);
             Result<string, Exception> mappedResult = result.Map(v => v.ToString()!);
             IsTrue(mappedResult.IsError);
-            try {
+            try
+            {
                 _ = mappedResult.Unwrap;
                 Fail("Expected exception was not thrown");
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 AreSame(_testError, ex);
             }
         }
 
         [TestMethod]
-        public void MapOrTest() {
+        public void MapOrTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             object mappedResult = result.MapOr(v => v.ToString()!, new object());
             AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
-        public void MapOrNullTest() {
+        public void MapOrNullTest()
+        {
             Error<object, Exception> result = new(_testError);
             object mappedResult = result.MapOr(v => v.ToString()!, _testValue);
             AreSame(_testValue, mappedResult);
         }
 
         [TestMethod]
-        public void MapOrElseTest() {
+        public void MapOrElseTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             string mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testValue.ToString(), mappedResult);
         }
 
         [TestMethod]
-        public void MapOrElseNullTest() {
+        public void MapOrElseNullTest()
+        {
             Error<object, Exception> result = new(_testError);
             string mappedResult = result.MapOrElse(v => v.ToString()!, e => e.Message);
             AreSame(_testError.Message, mappedResult);
         }
 
         [TestMethod]
-        public void MapErrorDiffTest() {
+        public void MapErrorDiffTest()
+        {
             Error<object, Exception> result = new(_testError);
             const string message = "Mapped Error";
             Result<object, Exception> mappedResult = result.MapError(e => new Exception(message));
             IsTrue(mappedResult.IsError);
-            try {
+            try
+            {
                 _ = mappedResult.Unwrap;
                 Fail("Expected exception was not thrown");
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 AreNotSame(_testError, ex);
                 AreSame(ex.Message, message);
             }
         }
 
         [TestMethod]
-        public void MapErrorNullTest() {
+        public void MapErrorNullTest()
+        {
             Ok<object, Exception> result = new(_testValue);
             Result<object, Exception> mappedResult = result.MapError(e => new Exception("Mapped Error"));
             IsTrue(mappedResult.IsOk);

--- a/MonadsTests/ResultTests.cs
+++ b/MonadsTests/ResultTests.cs
@@ -1,4 +1,5 @@
 using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+#pragma warning disable IDE0039 // Použít lokální funkci
 
 namespace Monads.Tests
 {
@@ -55,7 +56,7 @@ namespace Monads.Tests
         [TestMethod]
         public void ExpectErrorTest()
         {
-            string msg = "Error";
+            const string msg = "Error";
             Result<object, Exception> result = new Error<object, Exception>(_testError);
             try
             {
@@ -64,7 +65,7 @@ namespace Monads.Tests
             }
             catch (Exception ex)
             {
-                AreSame(ex.Message, msg);
+                AreSame(msg, ex.Message);
             }
         }
 
@@ -72,7 +73,7 @@ namespace Monads.Tests
         public void IsOkAndTest()
         {
             Result<object, Exception> result = new Ok<object, Exception>(_testValue);
-            Func<object, bool> predicate = (object v) => v is not null;
+            Func<object, bool> predicate = static (object v) => v is not null;
             IsTrue(result.IsOkAnd(predicate));
         }
 
@@ -80,7 +81,7 @@ namespace Monads.Tests
         public void IsOkAndFalseTest()
         {
             Result<object, Exception> result = new Ok<object, Exception>(_testValue);
-            Func<object, bool> predicate = (object v) => v is null;
+            Func<object, bool> predicate = static (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
@@ -88,7 +89,7 @@ namespace Monads.Tests
         public void IsErrorAndTest()
         {
             Result<object, Exception> result = new Error<object, Exception>(_testError);
-            Func<Exception, bool> predicate = (Exception e) => e.Message == _testError.Message;
+            Func<Exception, bool> predicate = static (Exception e) => e.Message == _testError.Message;
             IsTrue(result.IsErrorAnd(predicate));
         }
 
@@ -96,7 +97,7 @@ namespace Monads.Tests
         public void IsErrorAndFalseTest()
         {
             Result<object, Exception> result = new Error<object, Exception>(_testError);
-            Func<Exception, bool> predicate = (Exception e) => e.Message == "Different Error";
+            Func<Exception, bool> predicate = static (Exception e) => e.Message == "Different Error";
             IsFalse(result.IsErrorAnd(predicate));
         }
 
@@ -104,7 +105,7 @@ namespace Monads.Tests
         public void IsErrorAndNullTest()
         {
             Result<object, Exception> result = new Error<object, Exception>(_testError);
-            Func<Exception, bool> predicate = (Exception e) => e is null;
+            Func<Exception, bool> predicate = static (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
@@ -112,7 +113,7 @@ namespace Monads.Tests
         public void IsOkAndNullTest()
         {
             Result<object, Exception> result = new Ok<object, Exception>(_testValue);
-            Func<object, bool> predicate = (object v) => v is null;
+            Func<object, bool> predicate = static (object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
@@ -120,7 +121,7 @@ namespace Monads.Tests
         public void IsOkAndNullPredicateTest()
         {
             Result<object, Exception> result = new Ok<object, Exception>(_testValue);
-            Func<object, bool> predicate = (object v) => v is null;
+            Func<object, bool> predicate = static(object v) => v is null;
             IsFalse(result.IsOkAnd(predicate));
         }
 
@@ -128,7 +129,7 @@ namespace Monads.Tests
         public void IsErrorAndNullPredicateTest()
         {
             Result<object, Exception> result = new Error<object, Exception>(_testError);
-            Func<Exception, bool> predicate = (Exception e) => e is null;
+            Func<Exception, bool> predicate = static (Exception e) => e is null;
             IsFalse(result.IsErrorAnd(predicate));
         }
 
@@ -233,7 +234,7 @@ namespace Monads.Tests
             catch (Exception ex)
             {
                 AreNotSame(_testError, ex);
-                AreSame(ex.Message, message);
+                AreSame(message, ex.Message);
             }
         }
 
@@ -267,7 +268,7 @@ namespace Monads.Tests
         {
             ArgumentException exception = new();
             Func<string> testFunc = () => false ? string.Empty : throw exception;
-            Result<string, InvalidOperationException> result = default!;
+            Result<string, InvalidOperationException>? result = default;
             try
             {
                 result = testFunc.TryExecute<string, InvalidOperationException>();
@@ -281,3 +282,4 @@ namespace Monads.Tests
         }
     }
 }
+#pragma warning restore IDE0039 // Použít lokální funkci


### PR DESCRIPTION
## Additions
Exec is now TryExecute and contained outside the Result class.
It now also properly throws if an unexpected Exception is encountered.

There are three test written for it, containing all cases.

## Rename & style
### Naming
* Renamed backing fields
* Err is now Error
* Names of parameters are now clearer
### Style
* classes and methods are now properly formatted
	- proper multi-parameter spacing in type parameters (eg. `Result<T, E>`)
* strict Allman-style brackets
* Reduced one-liner if statements

## Optimalization
* `IsOk` and `IsError` now tell compiler about `null` certainty
* `IsError` doesn't call to `IsOk`
* `IsOkAnd` and `IsErrorAnd` have better condition assertion