### PR TITLE
Add tests for Option

### DIFF
--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -126,7 +126,7 @@
     /// </summary>
     /// <typeparam name="T">the desired underlying type</typeparam>
     /// <param name="value">value to store</param>
-    public class Some<T>(T value) : Option<T>(value) where T : class;
+    public class Some<T>(T value) : Option<T>(value ?? throw new ArgumentNullException(nameof(value))) where T : class;
 
     /// <summary>
     /// A shorthnd to create an <see cref="Option{T}.None"/>

--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -91,6 +91,16 @@
         /// </returns>
         public T ValueOrDefault(T orElse) => _value ?? orElse;
         
+        /// <summary>
+        /// Creates a new <see cref="Option{T}"/> object, wrapping the provided <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">the value to wrap</param>
+        /// <returns>
+        /// An <see cref="Option{T}.Some(T)"/> if the <paramref name="value"/> is not <see langword="null"/>.
+        /// Otherwise a <see cref="Option{T}.None"/>.
+        /// </returns>
+        public static implicit operator Option<T>(T? value) => new(value);
+        
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
         public bool Equals(Option<T>? other)
             => other is not null && this.GetHashCode() == other.GetHashCode();

--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -126,10 +126,12 @@
     /// </summary>
     /// <typeparam name="T">the desired underlying type</typeparam>
     /// <param name="value">value to store</param>
-    public class Some<T>(T value) : Option<T>(value ?? throw new ArgumentNullException(nameof(value))) where T : class;
+    public class Some<T>(T value)
+        : Option<T>(value ?? throw new ArgumentNullException(nameof(value)))
+        where T : class;
 
     /// <summary>
-    /// A shorthnd to create an <see cref="Option{T}.None"/>
+    /// A shorthand to create an <see cref="Option{T}.None"/>
     /// </summary>
     /// <typeparam name="T">the type of the value that is missing</typeparam>
     public class None<T>() : Option<T>() where T : class;

--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -34,6 +34,7 @@
         /// Creates an <see cref="Option{T}"/> that contains a value of type <typeparamref name="T"/>
         /// </summary>
         /// <param name="value">value to store</param>
+        /// <exception cref="ArgumentNullException">The provided value was <see langword="null"/></exception>
         /// <returns>An <see cref="Option{T}"/> with some value of type <typeparamref name="T"/></returns>
         public static Option<T> Some(T value) => new(value ?? throw new ArgumentNullException(nameof(value)));
 
@@ -136,6 +137,7 @@
     /// </summary>
     /// <typeparam name="T">the desired underlying type</typeparam>
     /// <param name="value">value to store</param>
+    /// <exception cref="ArgumentNullException">The provided value was <see langword="null"/></exception>
     public class Some<T>(T value)
         : Option<T>(value ?? throw new ArgumentNullException(nameof(value)))
         where T : class;

--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -90,7 +90,7 @@
         /// Otherwise, <paramref name="orElse"/> is returned.
         /// </returns>
         public T ValueOrDefault(T orElse) => _value ?? orElse;
-        
+
         /// <summary>
         /// Creates a new <see cref="Option{T}"/> object, wrapping the provided <paramref name="value"/>.
         /// </summary>
@@ -100,7 +100,7 @@
         /// Otherwise a <see cref="Option{T}.None"/>.
         /// </returns>
         public static implicit operator Option<T>(T? value) => new(value);
-        
+
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
         public bool Equals(Option<T>? other)
             => other is not null && this.GetHashCode() == other.GetHashCode();

--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -128,7 +128,7 @@
         public override bool Equals(object? obj) => Equals(obj as Option<T>);
         internal const string _none = "None";
         /// <inheritdoc cref="object.ToString"/>
-        public override string ToString() => $"{_value?.ToString() ?? _none}";
+        public override string ToString() => _value?.ToString() ?? _none;
     }
 
     /// <summary>

--- a/Monads/Option.cs
+++ b/Monads/Option.cs
@@ -35,13 +35,13 @@
         /// </summary>
         /// <param name="value">value to store</param>
         /// <returns>An <see cref="Option{T}"/> with some value of type <typeparamref name="T"/></returns>
-        public static Option<T> Some(T value) => new(value);
+        public static Option<T> Some(T value) => new(value ?? throw new ArgumentNullException(nameof(value)));
 
         /// <summary>
         /// Creates an <see cref="Option{T}"/> with no underlying value
         /// </summary>
         /// <returns>An <see cref="Option{T}"/> containing nothing</returns>
-        public static Option<T> None() => new(null);
+        public static Option<T> None() => new();
 
         /// <summary>
         /// Tries to commit an operation with the possible underlying value.

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -78,6 +78,17 @@ namespace Monads.Tests
         public void InspectTest()
         {
             //throw new NotImplementedException();
+
+        [TestMethod]
+        public void CastTest()
+        {
+            Option<object> some = _fine;
+            IsTrue(some.HasValue);
+            _ = some.Value;
+
+            Option<object> none = _faulty;
+            IsFalse(none.HasValue);
+            _ = ThrowsException<InvalidOperationException>(() => none.Value);
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -6,6 +6,57 @@ namespace Monads.Tests
     public class OptionTests
     {
         [TestMethod]
-        public void ExistsTest() => IsTrue(true);
+        public void SomeTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void NoneTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void BindTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void InspectTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void MapTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void ValueOrDefaultTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void EqualsTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void GetHashCodeTest()
+        {
+            //throw new NotImplementedException();
+        }
+
+        [TestMethod]
+        public void ToStringTest()
+        {
+            //throw new NotImplementedException();
+        }
     }
 }

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -43,7 +43,9 @@ namespace Monads.Tests
         [TestMethod]
         public void NoneTest()
         {
-            //throw new NotImplementedException();
+            Option<object> noneO = Option<object>.None();
+            Option<object> noneC = new None<object>();
+            IsFalse(noneO.HasValue); IsFalse(noneC.HasValue);
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -72,7 +72,17 @@ namespace Monads.Tests
         [TestMethod]
         public void ValueOrDefaultTest()
         {
-            //throw new NotImplementedException();
+            object the = new();
+            Option<object> obj = Option<object>.Some(the);
+            Option<string> str = Option<string>.Some((string)_fine);
+            AreEqual(the, obj.ValueOrDefault(_testString));
+            AreEqual(_testString, str.ValueOrDefault(the.ToString()!));
+
+            Option<object> noObj = Option<object>.None();
+            Option<string> noStr = Option<string>.None();
+            AreEqual(the, noObj.ValueOrDefault(the));
+            AreEqual(_testString, noObj.ValueOrDefault(_testString));
+            AreEqual(_testString, noStr.ValueOrDefault(_testString));
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -1,4 +1,5 @@
-﻿using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+﻿using System.Diagnostics.CodeAnalysis;
+using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace Monads.Tests
 {
@@ -77,13 +78,17 @@ namespace Monads.Tests
         [TestMethod]
         public void EqualsTest()
         {
-            //throw new NotImplementedException();
-        }
+            Option<object> someO = Option<object>.Some(_fine);
+            Option<object> someC = new Some<object>(_fine);
+            IsTrue(someO.Equals((object)someC)); IsTrue(someC.Equals((object)someO));
+            IsTrue(someO.Equals(someC)); IsTrue(someC.Equals(someO));
+            IsFalse(someO != someC); IsFalse(someC != someO);
 
-        [TestMethod]
-        public void GetHashCodeTest()
-        {
-            //throw new NotImplementedException();
+            Option<object> noneO = Option<object>.None();
+            Option<object> noneC = new None<object>();
+            IsTrue(noneO.Equals((object)noneC)); IsTrue(noneC.Equals((object)noneO));
+            IsTrue(noneO.Equals(noneC)); IsTrue(noneC.Equals(noneO));
+            IsFalse(noneO != noneC); IsFalse(noneC != noneO);
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -9,6 +9,8 @@ namespace Monads.Tests
         // Set in Prepare
         private static object _faulty;
         private static object _fine;
+        private const string _testString = "Ahoj";
+        internal const string _none = "None";
 #pragma warning restore CS8618 // Pole, které nemůže být null, musí při ukončování konstruktoru obsahovat hodnotu, která není null.
 
         // public TestContext TestContext { get; set; }
@@ -16,8 +18,8 @@ namespace Monads.Tests
         [ClassInitialize]
         public static void Prepare(TestContext context)
         {
-            _fine = new();
-            _faulty = null!;            
+            _fine = _testString;
+            _faulty = null!;
             Console.WriteLine($"Started {nameof(OptionTests)}");
         }
 
@@ -87,7 +89,11 @@ namespace Monads.Tests
         [TestMethod]
         public void ToStringTest()
         {
-            //throw new NotImplementedException();
+            Option<object> some = Option<object>.Some(_fine);
+            AreEqual(_fine.ToString(), some.ToString());
+
+            Option<object> none = Option<object>.None();
+            AreEqual(_none, none.ToString());
         }
     }
 }

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -108,7 +108,32 @@ namespace Monads.Tests
         [TestMethod]
         public void MapTest()
         {
-            //throw new NotImplementedException();
+            const string doesnt = "doesn\'t exist";
+            const string exists = _testString + " exists";
+
+            Option<string> some = (string)_fine;
+            int len = some.Map(
+                s => s.Length,
+                () => 0
+            );
+            AreEqual(_testString.Length, len);
+            string mod = some.Map(
+                s => $"{s} exists",
+                () => doesnt
+            );
+            AreEqual(exists, mod);
+
+            Option<string> none = (string?)null;
+            len = none.Map(
+                s => s.Length,
+                () => 0
+            );
+            AreEqual(0, len);
+            mod = none.Map(
+                s => $"{s} exists",
+                () => doesnt
+            );
+            AreEqual(doesnt, mod);
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+﻿using static Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace Monads.Tests
 {
@@ -17,6 +16,7 @@ namespace Monads.Tests
         // public TestContext TestContext { get; set; }
 
         [ClassInitialize]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Odebrat nepoužívaný parametr", Justification = "Součástí API")]
         public static void Prepare(TestContext context)
         {
             _fine = _testString;
@@ -36,8 +36,9 @@ namespace Monads.Tests
         {
             Option<object> someO = Option<object>.Some(_fine);
             Option<object> someC = new Some<object>(_fine);
-            IsNotNull(someO); IsNotNull(someC);
             IsTrue(someO.HasValue); IsTrue(someC.HasValue);
+            _ = someO.Value;
+            _ = someC.Value;
 
             _ = ThrowsException<ArgumentNullException>(() => Option<object>.Some(_faulty));
             _ = ThrowsException<ArgumentNullException>(() => _ = new Some<object>(_faulty));
@@ -49,6 +50,8 @@ namespace Monads.Tests
             Option<object> noneO = Option<object>.None();
             Option<object> noneC = new None<object>();
             IsFalse(noneO.HasValue); IsFalse(noneC.HasValue);
+            _ = ThrowsException<InvalidOperationException>(() => _ = noneO.Value);
+            _ = ThrowsException<InvalidOperationException>(() => _ = noneC.Value);
         }
 
         [TestMethod]
@@ -88,12 +91,20 @@ namespace Monads.Tests
         [TestMethod]
         public void EqualsTest()
         {
-            Option<object> someO = Option<object>.Some(_fine);
-            Option<object> someC = new Some<object>(_fine);
-            IsTrue(someO.Equals((object)someC)); IsTrue(someC.Equals((object)someO));
-            IsTrue(someO.Equals(someC)); IsTrue(someC.Equals(someO));
-            IsFalse(someO != someC); IsFalse(someC != someO);
-
+            // Reference equality
+            object obj = new();
+            Option<object> objO = Option<object>.Some(obj);
+            Option<object> objC = new Some<object>(obj);
+            IsTrue(objO.Equals((object)objC)); IsTrue(objC.Equals((object)objO));
+            IsTrue(objO.Equals(objC)); IsTrue(objC.Equals(objO));
+            IsFalse(objO != objC); IsFalse(objC != objO);
+            // Value equality
+            Option<object> strO = Option<object>.Some(_fine);
+            Option<object> strC = new Some<object>(_testString);
+            IsTrue(strO.Equals((object)strC)); IsTrue(strC.Equals((object)strO));
+            IsTrue(strO.Equals(strC)); IsTrue(strC.Equals(strO));
+            IsFalse(strO != strC); IsFalse(strC != strO);
+            // None equality
             Option<object> noneO = Option<object>.None();
             Option<object> noneC = new None<object>();
             IsTrue(noneO.Equals((object)noneC)); IsTrue(noneC.Equals((object)noneO));

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -31,7 +31,13 @@ namespace Monads.Tests
         [TestMethod]
         public void SomeTest()
         {
-            //throw new NotImplementedException();
+            Option<object> someO = Option<object>.Some(_fine);
+            Option<object> someC = new Some<object>(_fine);
+            IsNotNull(someO); IsNotNull(someC);
+            IsTrue(someO.HasValue); IsTrue(someC.HasValue);
+
+            _ = ThrowsException<ArgumentNullException>(() => Option<object>.Some(_faulty));
+            _ = ThrowsException<ArgumentNullException>(() => _ = new Some<object>(_faulty));
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -57,7 +57,21 @@ namespace Monads.Tests
         [TestMethod]
         public void BindTest()
         {
-            //throw new NotImplementedException();
+            Option<string> someInit = Option<string>.Some((string)_fine);
+            Option<string> someNext = someInit.Bind(s  => string.Concat(s, " světe"));
+            Option<string> someLast = someNext.Bind(s => string.Concat(s, "!"));
+            const string mid = _testString + " světe";
+            const string end = mid + "!";
+            IsTrue(someNext.HasValue && someLast.HasValue);
+            AreEqual(mid, someNext.Value);
+            AreEqual(end, someLast.Value);
+
+            Option<string> noneInit = Option<string>.None();
+            Option<string> noneNext = noneInit.Bind(s => string.Concat(s, " světe"));
+            Option<string> noneLast = noneNext.Bind(s => string.Concat(s, "!"));
+            IsFalse(noneNext.HasValue); IsFalse(noneLast.HasValue);
+            _ = ThrowsException<InvalidOperationException>(() => _ = noneNext.Value);
+            _ = ThrowsException<InvalidOperationException>(() => _ = noneLast.Value);
         }
 
         [TestMethod]

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -77,7 +77,21 @@ namespace Monads.Tests
         [TestMethod]
         public void InspectTest()
         {
-            //throw new NotImplementedException();
+            bool? outsideVar = null;
+            void ResetVar() => outsideVar = null;
+            void Some(object _) => outsideVar = true;
+            void None() => outsideVar = false;
+
+            Option<string> some = Option<string>.Some((string)_fine);
+            some.Inspect(Some, None);
+            IsTrue(outsideVar);
+            ResetVar();
+
+            Option<object> none = Option<object>.None();
+            none.Inspect(Some, None);
+            IsFalse(outsideVar);
+            ResetVar();
+        }
 
         [TestMethod]
         public void CastTest()

--- a/MonadsTests/OptionTests.cs
+++ b/MonadsTests/OptionTests.cs
@@ -5,6 +5,29 @@ namespace Monads.Tests
     [TestClass]
     public class OptionTests
     {
+#pragma warning disable CS8618 // Pole, které nemůže být null, musí při ukončování konstruktoru obsahovat hodnotu, která není null.
+        // Set in Prepare
+        private static object _faulty;
+        private static object _fine;
+#pragma warning restore CS8618 // Pole, které nemůže být null, musí při ukončování konstruktoru obsahovat hodnotu, která není null.
+
+        // public TestContext TestContext { get; set; }
+
+        [ClassInitialize]
+        public static void Prepare(TestContext context)
+        {
+            _fine = new();
+            _faulty = null!;            
+            Console.WriteLine($"Started {nameof(OptionTests)}");
+        }
+
+        [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
+        public static void Cleanup()
+        {
+            _fine = null!;
+            Console.WriteLine($"Ended {nameof(OptionTests)}");
+        }
+
         [TestMethod]
         public void SomeTest()
         {

--- a/MonadsTests/Program.cs
+++ b/MonadsTests/Program.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.ClassLevel, Workers = 4)]

--- a/MonadsTests/Program.cs
+++ b/MonadsTests/Program.cs
@@ -1,1 +1,2 @@
 ﻿[assembly: Parallelize(Scope = ExecutionScope.ClassLevel, Workers = 4)]
+[assembly: ClassCleanupExecution(ClassCleanupBehavior.EndOfClass)]


### PR DESCRIPTION
## Tests
- class init. and cleanup
- construction tests - `Some` and `None` methods and classes
- equality test - `Equals(object?)`, eq. operators and `Equals(Option<T>?)`
- string conversion test (the `ToString` method)
- tests to validate the newly added implicit casting
- monad stuff tests - bind, map, ValOrDef and inspect methods

## Fixes
Sanitized inputs to `Option<T>.Some` and `new Some<T>`.
They previously didn't throw an `ArgumentNullException` when the input value was `null`.

`Option<T>.None` now doesn't force a `null` into the constructor. *1 operation less, yay!*

Simplified `ToString` method - one string allocation less, since we used to box the result in an interpolated string because who-knows-why.

Fixed a typo in summary documentation of `None<T>`

## Additions
Added Parallelization to tests.
Also defined behaviour of test class cleanup.

Added an implicit operator to cast a value of type `T?` to `Option<T>`.

It has to be implicit, since the explicit cast gets overridden by reference casting and causes bugs. It is a null reference when the casted object actually is `null`, instead of being the desired `Option<T>.None`.
It also causes exceptions when casting upcasted (contravariant) `object`, since it is not castable to `Option<T>`.